### PR TITLE
Tile render enhanced

### DIFF
--- a/serverless/api/handler.py
+++ b/serverless/api/handler.py
@@ -290,6 +290,9 @@ class Handler:
         # Blend the raw tiles
         composite = blend.composite_channels(channels)
 
+        # CV2 requires 0 - 255 values
+        composite *= 255
+
         # Encode rendered image as PNG
         return cv2.imencode('.png', composite)[1]
 

--- a/serverless/api/handler.py
+++ b/serverless/api/handler.py
@@ -346,7 +346,7 @@ class Handler:
 
         # Fetch raw tiles in parallel
         pool = ThreadPool(processes=len(channels))
-        images = pool.starmap(self._s3_get, args)
+        images = pool.starmap(_s3_get, args)
         pool.close()
 
         # Update channel dictionary with image data


### PR DESCRIPTION
- Fix a rendering bug in CV where all images would render to almost totally darkness.
- If requesting a tile that does not exist, throw an appropriate error response based on the metadata of the image. I.e. 404 and an explanation as to the reason it does not exists (e.g. requesting a channel which doesn't exist)