### PR TITLE
Adds a launch script and template for cognito

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ It is comprised of some cloudformation and serverless configurations.
 - A pair of private subnets with NAT gateways configured in the VPC.
 - A default security group which allows communication in/out from itself.
 - A security group which allows SSH communication to EC2 instances as required.
-- A Cognito user pool.
 - A configuration file with these and some other properties.
 - Standard roles for `BatchServiceRole`, `BatchInstanceRole` and
   `BatchSpotFleetRole`.
@@ -46,8 +45,6 @@ BatchClusterSpotMinCpus: 0
 BatchClusterSpotMaxCpus: 16
 BatchClusterSpotDesiredCpus: 0
 BatchClusterSpotBidPercentage: 50
-# Cognito User Pool ARN
-CognitoUserPool: arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_12345678
 # Database password
 DatabasePassword: password
 ```
@@ -82,9 +79,10 @@ configuration file.
 ## Instructions
 
 1. Deploy the common cloudformation infrastructure
-2. Build the Batch AMI
-3. Deploy the Batch cloudformation infrastructure
-4. Deploy the db serverless infrastructure
-5. Deploy the batch serverless infrastructure
-6. Deploy the api serverless infrastructure
-7. Run AWS lambda `initdb` method to initialise the database
+2. Deploy the cognito cloudformation infrastructure
+3. Build the Batch AMI
+4. Deploy the Batch cloudformation infrastructure
+5. Deploy the db serverless infrastructure
+6. Deploy the batch serverless infrastructure
+7. Deploy the api serverless infrastructure
+8. Run AWS lambda `initdb` method to initialise the database

--- a/cloudformation/common/cognito.py
+++ b/cloudformation/common/cognito.py
@@ -22,20 +22,13 @@ def main():
         print('Error reading configuration YAML: {}'.format(e))
         sys.exit(1)
 
-    # Validate the number of subnets
-    if len(config['SubnetsPublic']) != 2:
-        print('Exactly 2 public subnets required')
-        sys.exit(1)
-
     region = config['Region']
     prefix = config['StackPrefix']
     stage = config['Stage']
-    name = '{}-cf-common'.format(prefix)
+    name = '{}-cf-cognito'.format(prefix)
     project_tag = config['ProjectTag']
-    subnets_public = ','.join(config['SubnetsPublic'])
-    database_password = config['DatabasePassword']
 
-    with open('main.yml', 'r') as f:
+    with open('cognito.yml', 'r') as f:
         template_body = f.read()
 
     cf = boto3.client('cloudformation', region_name=region)
@@ -43,7 +36,10 @@ def main():
     if args.operation == 'create':
         cf_method = cf.create_stack
     elif args.operation == 'update':
-        cf_method = cf.update_stack
+        print('Updating cognito not recommended because updating of a user '
+              'pool requiring replacement will result in an empty pool')
+        sys.exit(1)
+        # cf_method = cf.update_stack
     else:
         print('Method not implemented')
         sys.exit(1)
@@ -63,14 +59,6 @@ def main():
             {
                 'ParameterKey': 'ProjectTag',
                 'ParameterValue': project_tag
-            },
-            {
-                'ParameterKey': 'SubnetsPublic',
-                'ParameterValue': subnets_public
-            },
-            {
-                'ParameterKey': 'DatabasePassword',
-                'ParameterValue': database_password
             }
         ],
         Capabilities=[

--- a/cloudformation/common/cognito.yml
+++ b/cloudformation/common/cognito.yml
@@ -1,0 +1,109 @@
+Parameters:
+  StackPrefix:
+    Type: String
+    Description: Unique prefix used in related stacks for use by export
+  Stage:
+    Type: String
+    Description: Deployment stage
+  ProjectTag:
+    Type: String
+    Description: Project tag
+
+Resources:
+
+  CognitoUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: True
+      AutoVerifiedAttributes:
+        - email
+      DeviceConfiguration:
+        ChallengeRequiredOnNewDevice: False
+        DeviceOnlyRememberedOnUserPrompt: False
+      EmailVerificationMessage: !Sub |
+        Welcome to ${StackPrefix}-${Stage}.
+        Please verify your email address. Your verification code is {####}
+      EmailVerificationSubject: !Sub "Verification: ${StackPrefix}-${Stage}!"
+      LambdaConfig:
+        PreSignUp: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackPrefix}-${Stage}-createUser
+        # "PreSignUp": "arn:aws:lambda:us-east-1:292075781285:function:minerva-test-dev-createUser"
+        # "PreSignUp": "arn:aws:lambda:us-east-1:292075781285:function:minerva-test-dev-createUser"
+        # arn:aws:cognito-idp:us-east-1:292075781285:userpool/us-east-1_jQEOV70H8
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 8
+          RequireLowercase: True
+          RequireNumbers: True
+          RequireSymbols: True
+          RequireUppercase: True
+      Schema:
+        - Name: name
+          AttributeDataType: String
+          Mutable: true
+          Required: true
+        - Name: email
+          AttributeDataType: String
+          Mutable: true
+          Required: true
+        - Name: preferred_username
+          AttributeDataType: String
+          Mutable: true
+          Required: true
+      UsernameAttributes:
+        - email
+      UserPoolName: !Sub ${StackPrefix}-${Stage}-UserPool
+      UserPoolTags:
+        project: !Ref ProjectTag
+
+  WebClient:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+        ClientName: web-client
+        ReadAttributes:
+          - address
+          - birthdate
+          - email
+          - email_verified
+          - family_name
+          - gender
+          - given_name
+          - locale
+          - middle_name
+          - name
+          - nickname
+          - phone_number
+          - phone_number_verified
+          - picture
+          - preferred_username
+          - profile
+          - zoneinfo
+          - updated_at
+          - website
+        UserPoolId: !Ref CognitoUserPool
+        WriteAttributes:
+          - address
+          - birthdate
+          - email
+          - family_name
+          - gender
+          - given_name
+          - locale
+          - middle_name
+          - name
+          - nickname
+          - phone_number
+          - picture
+          - preferred_username
+          - profile
+          - zoneinfo
+          - updated_at
+          - website
+  # SSM
+  CognitoUserPoolARN:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /${StackPrefix}/${Stage}/common/CognitoUserPoolARN
+      Description: Cognito User Pool ARN
+      Type: String
+      Value: !GetAtt CognitoUserPool.Arn

--- a/cloudformation/common/main.yml
+++ b/cloudformation/common/main.yml
@@ -18,11 +18,6 @@ Parameters:
   #   Type: List<AWS::EC2::Subnet::Id>
   #   Description: Private subnet IDs. Must be exactly two and be internet routeable!
 
-  # TODO Create the cognito user pool in cloudformation
-  CognitoUserPool:
-    Type: String
-    Description: Cognito User Pool ARN
-
   DatabasePassword:
     Type: String
     Description: Database password
@@ -195,14 +190,6 @@ Resources:
                   - !Sub ${RawBucket.Arn}/*
 
   # SSM
-  CognitoUserPoolARN:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub /${StackPrefix}/${Stage}/common/CognitoUserPoolARN
-      Description: Cognito User Pool ARN
-      Type: String
-      Value: !Ref CognitoUserPool
-
   EFSID:
     Type: AWS::SSM::Parameter
     Properties:

--- a/serverless/db/serverless.yml
+++ b/serverless/db/serverless.yml
@@ -355,10 +355,6 @@ functions:
     name: ${self:provider.environment.STACK_PREFIX}-${self:provider.environment.STAGE}-queryDb
     handler: internal._query_db
 
-  dummyDb:
-    name: ${self:provider.environment.STACK_PREFIX}-${self:provider.environment.STAGE}-dummyDb
-    handler: internal._dummy_db
-
   createBfu:
     name: ${self:provider.environment.STACK_PREFIX}-${self:provider.environment.STAGE}-createBfu
     handler: internal.create_bfu
@@ -370,6 +366,10 @@ functions:
   setBFUComplete:
     name: ${self:provider.environment.STACK_PREFIX}-${self:provider.environment.STAGE}-setBFUComplete
     handler: internal.set_bfu_complete
+
+  createUser:
+    name: ${self:provider.environment.STACK_PREFIX}-${self:provider.environment.STAGE}-createUser
+    handler: internal.create_user
 
   #
   # list_repositories_for_user:
@@ -454,6 +454,17 @@ resources:
           Fn::GetAtt:
             - SetBFUCompleteLambdaFunction
             - Arn
+
+    TriggerPolicyCreateUser:
+      Type: AWS::Lambda::Permission
+      Properties:
+        Action: lambda:InvokeFunction
+        FunctionName:
+          Fn::GetAtt:
+            - CreateUserLambdaFunction
+            - Arn
+        Principal: cognito-idp.amazonaws.com
+        SourceArn: "${ssm:/${self:provider.environment.STACK_PREFIX}/${self:provider.environment.STAGE}/common/CognitoUserPoolARN}"
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
Instead of requiring a cognito pool as a prerequisite, deploy it as a resource.

As updating cognito user pools can replace the pool (depending on the operation) this is disabled for now.

Resolves #3 
