### PR TITLE
Removed hardcoded AccountId from AssumedS3RoleRead & AssumedS3RoleWrite

### DIFF
--- a/cloudformation/common/main.yml
+++ b/cloudformation/common/main.yml
@@ -143,7 +143,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: arn:aws:iam::292075781285:root
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
             Action: sts:AssumeRole
       Policies:
         - PolicyName: !Sub ${StackPrefix}-${Stage}-AssumedS3RoleReadPolicy
@@ -171,7 +171,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: arn:aws:iam::292075781285:root
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
             Action: sts:AssumeRole
       Policies:
         - PolicyName: !Sub ${StackPrefix}-${Stage}-AssumedS3RoleWritePolicy


### PR DESCRIPTION
This issue prevented lambda functions like `getImportCredentials` to run `sts:AssumeRole` 
```
EEE Get Import Credentials EEE
"Error 500 (Internal Server Error): {\"error\": \"An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::753692341600:assumed-role/minerva-test-dev-serverless-db-dev-eu-west-1-lambdaRole/minerva-test-dev-getImportCredentials is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::753692341600:role/minerva-test-dev-AssumedS3RoleWrite\"}"
```
Will require running an update for the common cloudformation stack 
```
cd cloudformation/common
python common.py ../../../minerva-configs/test/config.yml update
```